### PR TITLE
SBT dependency is incorrect in ReadMe

### DIFF
--- a/java-client/build.sbt
+++ b/java-client/build.sbt
@@ -1,4 +1,4 @@
-name := "foorgol-java"
+name := "java-client"
 
 javaOptions += "-deprecation"
 

--- a/project/Foorgol.scala
+++ b/project/Foorgol.scala
@@ -8,7 +8,7 @@ object Foorgol extends Build {
 
   lazy val root = Project(id = "foorgol", base = file(".")).
     settings(
-      organization in ThisBuild := "fr.applicius",
+      organization in ThisBuild := "fr.applicius.foorgol",
       version in ThisBuild := "1.0.1-SNAPSHOT",
       scalaVersion in ThisBuild := "2.11.2").
     aggregate(java, scala)

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Foorgol help integration of some of these features.
 
 ## Usage
 
-Foorgool can be used in SBT projects adding dependency `"fr.applicius.foorgol" % "java-client" % "1.0-SNAPSHOT"` or `"fr.applicius.foorgol" %% "foorgol-scala" % "1.0-SNAPSHOT"` and having `"Applicius Snapshots" at "https://raw.github.com/applicius/mvn-repo/master/snapshots/"` in resolvers.
+Foorgool can be used in SBT projects adding dependency `"fr.applicius.foorgol" % "java-client" % "1.0.1-SNAPSHOT"` or `"fr.applicius.foorgol" %% "scala" % "1.0.1-SNAPSHOT"` and having `"Applicius Snapshots" at "https://raw.github.com/applicius/mvn-repo/master/snapshots/"` in resolvers.
 
 * Low-level [Java API](http://applicius.github.io/foorgol/java-client/api/)
 * [Scala API](http://applicius.github.io/foorgol/scala/api/#package)

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,11 +1,11 @@
-name := "foorgol-scala"
+name := "scala"
 
 javaOptions += "-deprecation"
 
 resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
 
 libraryDependencies ++= Seq(
-  "fr.applicius" % "foorgol-java" % version.value,
+  "fr.applicius.foorgol" % "java-client" % version.value,
   "org.scala-lang.modules" % "scala-xml_2.11" % "1.0.2",
   "com.jsuereth" % "scala-arm_2.11" % "1.4",
   "org.specs2" %% "specs2" % "2.4.1" % "test")


### PR DESCRIPTION
ReadMe suggests to add foorgol-scala sbt dependency as 

**"fr.applicius.foorgol"** %% "foorgol-scala" % "1.0-SNAPSHOT"

when it actually is

**"fr.applicius"** %% "foorgol-scala" % "1.0-SNAPSHOT"
